### PR TITLE
Fix/sources

### DIFF
--- a/etas/inversion.py
+++ b/etas/inversion.py
@@ -1676,6 +1676,9 @@ class ETASParameterCalculation:
         source_events_0["l_hat"] = (
             (Pij_0["Pij"] * Pij_0["zeta_plus_1"]).groupby(level=0).sum()
         )
+        # filling NaN with 0 to indicate
+        # that those sources have no aftershocks (yet)
+        source_events_0["l_hat"] = source_events_0["l_hat"].fillna(0)
 
         logger.debug(
             "    expectation step took {}".format(


### PR DESCRIPTION
This fix is to ensure that earthquakes that did not (yet) trigger any aftershocks, thus are not present in the Pij triggering probability matrix, are still considered potential sources. This is expected not have big effects on the inversion outcome, but can have crucial consequences when issuing a forecast:

If one runs the parameter inversion just after a large event occurred, before any aftershocks are recorded, this large event would previously not have been present in the self.sources and thus, no aftershocks of it would have been simulated in the forecast. But of course, a recent large event is expected to be the biggest contributor to the simulated event rate.